### PR TITLE
Add includeZones support to ATW devices.

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -829,6 +829,24 @@
                     "description": "Select device control mode displayed in HomeKit app.",
                     "required": true
                   },
+                  "includeZone1": {
+                    "title": "Include Zone 1",
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Show or hide Zone 1 thermostat."
+                  },
+                  "includeZone2": {
+                    "title": "Include Zone 2", 
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Show or hide Zone 2 thermostat."
+                  },
+                  "includeHotWater": {
+                    "title": "Include Hot Water", 
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Show or hide Hot Water thermostat."
+                  },
                   "temperatureSensor": {
                     "title": "Temperature Sensor Room",
                     "type": "boolean",
@@ -1829,17 +1847,20 @@
                     },
                     "accounts[].atwDevices[].displayMode",
                     {
-                      "key": "accounts[].atwDevices[]",
-                      "type": "section",
-                      "title": "Settings",
-                      "expandable": true,
-                      "expanded": false,
-                      "items": [
-                        "accounts[].atwDevices[].name",
-                        "accounts[].atwDevices[].refreshInterval"
-                      ]
-                    },
-                    {
+  "key": "accounts[].atwDevices[]",
+  "type": "section",
+  "title": "Settings",
+  "expandable": true,
+  "expanded": false,
+  "items": [
+    "accounts[].atwDevices[].name",
+    "accounts[].atwDevices[].refreshInterval",
+    "accounts[].atwDevices[].includeZone1",
+    "accounts[].atwDevices[].includeZone2",
+    "accounts[].atwDevices[].includeHotWater"
+  ]
+},
+{
                       "key": "accounts[].atwDevices[]",
                       "type": "section",
                       "title": "Presets",

--- a/src/deviceatw.js
+++ b/src/deviceatw.js
@@ -17,7 +17,12 @@ class DeviceAtw extends EventEmitter {
 
         //account config
         this.displayMode = device.displayMode;
-        this.temperatureSensor = device.temperatureSensor || false;
+	    this.includeZones = [
+            device.includeZone1 ?? true, //unsure if these are named correctly.
+            device.includeZone2 ?? true, //unsure if these are named correctly.
+            device.includeHotWater ?? true //this is named correctly for a Mitsubishi Ecodan with FTC-6
+        ];
+	    this.temperatureSensor = device.temperatureSensor || false;
         this.temperatureSensorFlow = device.temperatureSensorFlow || false;
         this.temperatureSensorReturn = device.temperatureSensorReturn || false;
         this.temperatureSensorFlowZone1 = device.temperatureSensorFlowZone1 || false;
@@ -636,6 +641,7 @@ class DeviceAtw extends EventEmitter {
                         accessory.addService(melCloudService);
                         break;
                     case 2: //Thermostat
+			if (!this.includeZones[i]) break;  // Skip this zone if not included
                         const debug3 = this.enableDebugMode ? this.emit('debug', `Prepare thermostat ${zoneName} service`) : false;
                         const melCloudServiceT = new Service.Thermostat(serviceName, `Thermostat ${deviceId} ${i}`);
                         melCloudServiceT.getCharacteristic(Characteristic.CurrentHeatingCoolingState)

--- a/src/deviceatw.js
+++ b/src/deviceatw.js
@@ -1549,7 +1549,7 @@ class DeviceAtw extends EventEmitter {
                                 };
 
                                 //update characteristics
-                                if (this.melCloudServices) {
+                                if (this.melCloudServices && this.melCloudServices[i]) {
                                     this.melCloudServices[i]
                                         .updateCharacteristic(Characteristic.Active, power)
                                         .updateCharacteristic(Characteristic.CurrentHeaterCoolerState, currentOperationMode)
@@ -1557,8 +1557,13 @@ class DeviceAtw extends EventEmitter {
                                         .updateCharacteristic(Characteristic.CurrentTemperature, roomTemperature)
                                         .updateCharacteristic(Characteristic.LockPhysicalControls, lockPhysicalControl)
                                         .updateCharacteristic(Characteristic.TemperatureDisplayUnits, this.accessory.useFahrenheit);
-                                    const updateDefCool = heatCoolModes === 0 || heatCoolModes === 2 ? this.melCloudServices[i].updateCharacteristic(Characteristic.CoolingThresholdTemperature, setTemperature) : false;
-                                    const updateDefHeat = heatCoolModes === 0 || heatCoolModes === 1 ? this.melCloudServices[i].updateCharacteristic(Characteristic.HeatingThresholdTemperature, setTemperature) : false;
+
+                                    if (heatCoolModes === 0 || heatCoolModes === 2) {
+                                        this.melCloudServices[i].updateCharacteristic(Characteristic.CoolingThresholdTemperature, setTemperature);
+                                    }
+                                    if (heatCoolModes === 0 || heatCoolModes === 1) {
+                                        this.melCloudServices[i].updateCharacteristic(Characteristic.HeatingThresholdTemperature, setTemperature);
+                                    }
                                 }
                                 break;
                             case 2: //Thermostat


### PR DESCRIPTION
Using an Ecodan ATW heat pump with FTC6 controller, when adding the heat pump as a 'thermostat', three Home Accessories are created. 
One is Zone1, which is not optional, but I do not use. 
Another is unknown (labelled Heat Pump in Apple Home app), presumed Zone2, although this is inactive on my FTC6, MELCloud app, and is already catered for in the config schema. 
The third is the Hot Water cylinder, which I wanted to keep. 
This feature adds a config setting to check/uncheck Zone1/Zone2/Hot Water. This allows me to see only the useful thermostat in my Apple Home app. 
Not an excellent coder, this was largely created with AI support.