### PR TITLE
Fix: Only create HomeKit accessory for valid zones

### DIFF
--- a/src/deviceatw.js
+++ b/src/deviceatw.js
@@ -323,8 +323,9 @@ class DeviceAtw extends EventEmitter {
             //services
             if (zonesCount > 0) {
                 this.melCloudServices = [];
-                this.accessory.zones.forEach((zone, i) => {
-                    const zoneName = zone.name
+                for (let i = 0; i < zonesCount; i++) {
+                    const zone = this.accessory.zones[i];
+                    const zoneName = zone.name;
                     const serviceName = `${deviceTypeText} ${accessoryName}: ${zoneName}`;
                     switch (this.displayMode) {
                         case 1: //Heater Cooler
@@ -821,7 +822,7 @@ class DeviceAtw extends EventEmitter {
                             accessory.addService(melCloudServiceT);
                             break;
                     };
-                });
+                }
             };
 
             //sensor services


### PR DESCRIPTION
This fix an issue where undefined zone were being created for devices that do not have all possible zones enabled.

Previously, the code iterated over a static zones array, which could result in the creation of services for zones that did not exist on the actual device. This led to log messages and HomeKit accessories with "undefined" names.