### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -7,6 +7,10 @@ on:
 
 jobs:
   stale:
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/stale@v8


### PR DESCRIPTION
Potential fix for [https://github.com/grzegorz914/homebridge-melcloud-control/security/code-scanning/1](https://github.com/grzegorz914/homebridge-melcloud-control/security/code-scanning/1)

In general, the fix is to define an explicit `permissions` block either at the workflow root (applies to all jobs) or at the job level, granting only the minimal scopes needed by the stale bot. Since this workflow only marks and closes issues and pull requests, it needs write access to `issues` and `pull-requests`, and typically `contents: read` is a safe default for most workflows. This directly addresses CodeQL’s recommendation to constrain `GITHUB_TOKEN` permissions.

The single best way to fix this without changing existing functionality is to add a `permissions` block under the `stale` job (near line 10), so that only this job’s token is scoped appropriately. Following CodeQL’s minimal starting point for this action, we will set `contents: write`, `issues: write`, and `pull-requests: write`. No additional methods, imports, or definitions are needed; only YAML configuration changes in `.github/workflows/stale.yml`.

Concretely:
- Edit `.github/workflows/stale.yml`.
- Under `jobs:`, inside the `stale:` job and before `runs-on: ubuntu-latest`, insert:

```yaml
    permissions:
      contents: write
      issues: write
      pull-requests: write
```

This keeps the existing schedule, steps, and behavior unchanged while constraining `GITHUB_TOKEN` explicitly.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
